### PR TITLE
fixed bug in gPath2dist with same-node comparison

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: geoGraph
 Type: Package
 Title: Walking Through the Geographic Space Using Graphs
-Version: 1.1.1.9015
+Version: 1.1.1.9016
 Authors@R: c(
     person("Thibaut", "Jombart", role = "aut"),
     person("Dominik", "Jud", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,9 @@
 
 ## New Features
 
-* Updated `makeHexGrid` to handle date line crossing gGraphs
+* Fixed bug in `gPath2dist` with same-node distances
+
+* Updated `makeHexGrid` to handle date line crossing `gGraph` objects
 
 * Updated `isInArea` to print a reproducible bounding box message 
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## New Features
 
-* Fixed bug in `gPath2dist` with same-node distances
+* Updated `gPath2dist` to now automatically return a vector or dist object based on the input type
 
 * Updated `makeHexGrid` to handle date line crossing `gGraph` objects
 

--- a/R/dijkstraBuffer.R
+++ b/R/dijkstraBuffer.R
@@ -68,7 +68,7 @@ dijkstraBuffer <- function(x, origin, d, res.type = c("nodes", "gGraph"), ...) {
 
   ## compute least-cost paths from origin
   paths <- dijkstraFrom(x, start = origin.node)
-  dists <- gPath2dist(paths, res.type = "vector")
+  dists <- gPath2dist(paths)
 
   ## extract destination node names
   dest.nodes <- sub(".*:", "", names(dists))

--- a/R/gPath2dist.R
+++ b/R/gPath2dist.R
@@ -82,4 +82,4 @@ gPath2dist <- function(m, diag = FALSE, upper = FALSE,
     res <- resDist
   }
   return(res)
-} # end gPath2dist # end gPath2dist
+} 

--- a/R/gPath2dist.R
+++ b/R/gPath2dist.R
@@ -53,7 +53,8 @@ gPath2dist <- function(m, diag = FALSE, upper = FALSE,
     origins <- sub(":.*", "", names(x))
     
     n <- (1 + sqrt(1 + 8 * L)) / 2
-    if (n != round(n)) {
+    n <- round(n)
+    if (n * (n - 1) / 2 != L) {
       stop(
         "Length of x does not match a number of pairwise comparisons; ",
         "cannot construct a 'dist' object. Use res.type = 'vector' instead."

--- a/R/gPath2dist.R
+++ b/R/gPath2dist.R
@@ -38,7 +38,6 @@ gPath2dist <- function(m, diag = FALSE, upper = FALSE,
   if (!inherits(m, "gPath")) {
     stop("m is not a gPath object.")
   }
-
   ## find the size of the dist object ##
   x <- m
   res.type <- match.arg(res.type)
@@ -49,27 +48,27 @@ gPath2dist <- function(m, diag = FALSE, upper = FALSE,
   if (is.null(names(x))) {
     stop("m must have non-NULL names.")
   }
-  x.names <- sub(":.*", "", names(x))
-  i <- 1
-  while (i < L && x.names[i] == x.names[i + 1]) {
-    i <- i + 1
-  }
-
-  resSize <- i + 1
-
   ## check size consistency
-  if (res.type == "dist" && L != (resSize * (resSize - 1L)) %/% 2L) {
-    stop(
-      "Length of x does not match a number of pairwise comparisons; ",
-      "cannot construct a 'dist' object. Use res.type = 'vector' instead."
-    )
+  if (res.type == "dist") {
+    origins <- sub(":.*", "", names(x))
+    
+    n <- (1 + sqrt(1 + 8 * L)) / 2
+    if (n != round(n)) {
+      stop(
+        "Length of x does not match a number of pairwise comparisons; ",
+        "cannot construct a 'dist' object. Use res.type = 'vector' instead."
+      )
+    }
+    resSize <- n
+    
+    # check that the origin nodes are not all the same
+    if (length(unique(origins)) == 1) {
+      stop("All paths in m have the same origin node; cannot construct a 'dist'. ",
+           "Use res.type = 'vector'.")
+    }
   }
-
-
   ## GET DISTANCES ##
   resDist <- sapply(x, function(e) sum(e$length_detail[[1]], na.rm = TRUE))
-
-
   ## BUILD RESULT ##
   ## type == dist
   if (res.type == "dist") {
@@ -79,6 +78,5 @@ gPath2dist <- function(m, diag = FALSE, upper = FALSE,
     ## type == vector (no change)
     res <- resDist
   }
-
   return(res)
-} # end gPath2dist
+} # end gPath2dist # end gPath2dist

--- a/R/gPath2dist.R
+++ b/R/gPath2dist.R
@@ -8,39 +8,37 @@
 #' [dijkstraFrom()].
 #' @param upper unused parameter added for consistency with [as.dist()].
 #' @param diag unused parameter added for consistency with [as.dist()].
-#' @param res.type a character string indicating what type of result should be
-#' returned: a \code{dist} object ('dist'), or a vector of distances
-#' ('vector'). Note that 'dist' should only be required for pairwise data, as
-#' output by dijkstraBetween (as opposed to dijkstraFrom).
+#' @param res.type deprecated parameter that is now ignored; the function
+#' automatically detects whether the input is from [dijkstraBetween()] or
+#' [dijkstraFrom()] and returns the appropriate output type.
 #' @return Either a [`dist`] object containing pairwise distances between
-#' nodes when \code{res.type = "dist"}, or a numeric vector of distances when
-#' \code{res.type = "vector"}.
+#' nodes the gPath object was constructed from dijkstraBetween(), 
+#' or a numeric vector of distances if the gPath object was constructed from dijkstraFrom().
 #' @examples
-#' ## for pairwise distances between multiple nodes you can use res.type = "dist"
+#' ## for pairwise distances between multiple a "dist" object is returned
 #' # select a few populations from the HGDP dataset
 #' hgdp.sub <- hgdp[getData(hgdp)$Population %in%
 #'   c("Balochi", "BantuKenya", "Papuan", "Pima")]
 #' hgdp.path <- dijkstraBetween(hgdp.sub) # compute shortest path
-#' gPath2dist(hgdp.path, res = "dist") # extract as dist object
-#' ## for distances from a single origin node to multiple we set res.type = "vector"
+#' gPath2dist(hgdp.path) # extract as dist object
+#' ## for distances from a single origin node to multiple the output is a vector of distances
 #' #' # choose an origin node
 #' start <- "24988"
 #' hgdp.path <- dijkstraFrom(hgdp.sub, start) # compute shortest path from origin
-#' gPath2dist(hgdp.path, res = "vector") # extract as vector of distances
+#' gPath2dist(hgdp.path) # extract as vector of distances
 #' @family dijkstra_methods
 
 # TODO think whether this should be a as.dist method for gPath
 
 #' @export
 gPath2dist <- function(m, diag = FALSE, upper = FALSE,
-                       res.type = c("dist", "vector")) {
+                       res.type = NULL) {
   # check that m is a gPath object
   if (!inherits(m, "gPath")) {
     stop("m is not a gPath object.")
   }
   ## find the size of the dist object ##
   x <- m
-  res.type <- match.arg(res.type)
   L <- length(x)
   if (L < 1L) {
     stop("m must contain at least one element.")
@@ -48,35 +46,39 @@ gPath2dist <- function(m, diag = FALSE, upper = FALSE,
   if (is.null(names(x))) {
     stop("m must have non-NULL names.")
   }
-  ## check size consistency
-  if (res.type == "dist") {
-    origins <- sub(":.*", "", names(x))
-    
-    n <- (1 + sqrt(1 + 8 * L)) / 2
-    n <- round(n)
-    if (n * (n - 1) / 2 != L) {
-      stop(
-        "Length of x does not match a number of pairwise comparisons; ",
-        "cannot construct a 'dist' object. Use res.type = 'vector' instead."
-      )
-    }
-    resSize <- n
-    
-    # check that the origin nodes are not all the same
-    if (length(unique(origins)) == 1) {
-      stop("All paths in m have the same origin node; cannot construct a 'dist'. ",
-           "Use res.type = 'vector'.")
-    }
+  
+  ## deprecation: res.type is now ignored, type is auto-detected
+  if (!is.null(res.type)) {
+    message("res.type is deprecated; the function now returns a vector for ",
+            "dijkstraFrom outputs and a 'dist' object for dijkstraBetween ",
+            "outputs.")
   }
+  
+  ## check type
+  # check that the origin nodes are not all the same > djikstraFrom output
+  origins <- sub(":.*", "", names(x))
+  if (length(unique(origins)) == 1) {
+    type <- "from"
+  } else {
+    n <- (1 + sqrt(1 + 8 * L)) / 2
+    if (abs(n - round(n)) > 1e-9) {
+      stop("Length of m does not match a pairwise count and origins differ; ",
+           "cannot interpret as dijkstraBetween or dijkstraFrom output.")
+    }
+    n    <- round(n)
+    type <- "between"
+  }
+  
+  
   ## GET DISTANCES ##
   resDist <- sapply(x, function(e) sum(e$length_detail[[1]], na.rm = TRUE))
   ## BUILD RESULT ##
-  ## type == dist
-  if (res.type == "dist") {
-    res <- stats::dist(1:resSize)
+  ## type == between
+  if (type == "between") {
+    res <- stats::dist(1:n)
     res[] <- resDist
   } else {
-    ## type == vector (no change)
+    ## type == between (no change)
     res <- resDist
   }
   return(res)

--- a/man/gPath2dist.Rd
+++ b/man/gPath2dist.Rd
@@ -4,7 +4,7 @@
 \alias{gPath2dist}
 \title{Extract distances from a gPath object}
 \usage{
-gPath2dist(m, diag = FALSE, upper = FALSE, res.type = c("dist", "vector"))
+gPath2dist(m, diag = FALSE, upper = FALSE, res.type = NULL)
 }
 \arguments{
 \item{m}{a \code{gPath} object obtained by \code{\link[=dijkstraBetween]{dijkstraBetween()}} or
@@ -14,15 +14,14 @@ gPath2dist(m, diag = FALSE, upper = FALSE, res.type = c("dist", "vector"))
 
 \item{upper}{unused parameter added for consistency with \code{\link[=as.dist]{as.dist()}}.}
 
-\item{res.type}{a character string indicating what type of result should be
-returned: a \code{dist} object ('dist'), or a vector of distances
-('vector'). Note that 'dist' should only be required for pairwise data, as
-output by dijkstraBetween (as opposed to dijkstraFrom).}
+\item{res.type}{deprecated parameter that is now ignored; the function
+automatically detects whether the input is from \code{\link[=dijkstraBetween]{dijkstraBetween()}} or
+\code{\link[=dijkstraFrom]{dijkstraFrom()}} and returns the appropriate output type.}
 }
 \value{
 Either a \code{\link{dist}} object containing pairwise distances between
-nodes when \code{res.type = "dist"}, or a numeric vector of distances when
-\code{res.type = "vector"}.
+nodes the gPath object was constructed from dijkstraBetween(),
+or a numeric vector of distances if the gPath object was constructed from dijkstraFrom().
 }
 \description{
 This function extracts distances from a \code{gPath} object returned by
@@ -30,17 +29,17 @@ This function extracts distances from a \code{gPath} object returned by
 returns either a \code{\link{dist}} object or a numeric vector of distances.
 }
 \examples{
-## for pairwise distances between multiple nodes you can use res.type = "dist"
+## for pairwise distances between multiple a "dist" object is returned
 # select a few populations from the HGDP dataset
 hgdp.sub <- hgdp[getData(hgdp)$Population \%in\%
   c("Balochi", "BantuKenya", "Papuan", "Pima")]
 hgdp.path <- dijkstraBetween(hgdp.sub) # compute shortest path
-gPath2dist(hgdp.path, res = "dist") # extract as dist object
-## for distances from a single origin node to multiple we set res.type = "vector"
+gPath2dist(hgdp.path) # extract as dist object
+## for distances from a single origin node to multiple the output is a vector of distances
 #' # choose an origin node
 start <- "24988"
 hgdp.path <- dijkstraFrom(hgdp.sub, start) # compute shortest path from origin
-gPath2dist(hgdp.path, res = "vector") # extract as vector of distances
+gPath2dist(hgdp.path) # extract as vector of distances
 }
 \seealso{
 Other dijkstra_methods:

--- a/tests/testthat/test_dijkstra.R
+++ b/tests/testthat/test_dijkstra.R
@@ -59,21 +59,26 @@ testthat::test_that("DijkstraFrom works on a gData object", {
 })
 
 testthat::test_that("DijkstraBetween can handle two points on the same node in a gData object", {
-  # get a subset of the hgdp data where in two cases two populations are from the same node
-  hgdp_sub <- hgdp[getData(hgdp)$Region == "MIDDLE_EAST" | getData(hgdp)$Region == "CENTRAL_SOUTH_ASIA"]
-  pop <- getData(hgdp_sub)$Population
-
-  # compute the distances between all pairs of populations in this subset
+  hgdp_sub <- hgdp[getData(hgdp)$Region == "MIDDLE_EAST" |
+                     getData(hgdp)$Region == "CENTRAL_SOUTH_ASIA"]
+  pop      <- getData(hgdp_sub)$Population
+  nodes_id <- hgdp_sub@nodes.id
+  
   m <- dijkstraBetween(hgdp_sub)
-  vec <- geoGraph::gPath2dist(m, res.type = "vector")
-  dist <- geoGraph::gPath2dist(m)
-
-  # check that we get distances for all populations
-  testthat::expect_equal(attr(dist, "Size"), length(pop))
-
-  # check that the distances between populations from the same node is always zero
-  testthat::expect_equal(vec["39740:39740"][[1]], 0)
-  testthat::expect_equal(vec["16798:16798"][[1]], 0)
+  d <- geoGraph::gPath2dist(m)
+  
+  ## one entry per population
+  testthat::expect_equal(attr(d, "Size"), length(pop))
+  
+  ## every pair of populations sharing a graph node has distance 0
+  d_mat <- as.matrix(d)
+  for (i in seq_along(pop)) {
+    for (j in seq_along(pop)) {
+      if (i != j && nodes_id[i] == nodes_id[j]) {
+        testthat::expect_equal(d_mat[i, j], 0)
+      }
+    }
+  }
 })
 
 test_that("dijkstraBetween errors when from is empty", {

--- a/tests/testthat/test_gPath2dist.R
+++ b/tests/testthat/test_gPath2dist.R
@@ -21,53 +21,15 @@ test_that("gPath2dist dist object has correct size", {
   expect_equal(length(result), 6L)
 })
 
-test_that("gPath2dist returns a named vector with res.type = 'vector'", {
+test_that("gPath2dist returns a named vector for a djikstraFrom output", {
   hgdp.sub <- hgdp[c(1, 2, 3, 4), ]
-  hgdp.path <- dijkstraBetween(hgdp.sub)
-  result <- gPath2dist(hgdp.path, res.type = "vector")
+  hgdp.path <- dijkstraFrom(hgdp.sub, "24988")
+  result <- gPath2dist(hgdp.path)
 
   expect_true(is.numeric(result))
   expect_false(inherits(result, "dist"))
-  expect_equal(length(result), 6L)
-  expect_false(is.null(names(result)))
-})
-
-test_that("gPath2dist dist and vector return consistent distances", {
-  hgdp.sub <- hgdp[c(1, 2, 3, 4), ]
-  hgdp.path <- dijkstraBetween(hgdp.sub)
-
-  result.dist <- gPath2dist(hgdp.path, res.type = "dist")
-  result.vec <- gPath2dist(hgdp.path, res.type = "vector")
-
-  expect_equal(as.vector(result.dist), as.vector(result.vec))
-})
-
-test_that("gPath2dist gives an error when dijkstraFrom output is used with res.type = 'dist'", {
-  hgdp.sub <- hgdp[c(1, 2, 3, 4), ]
-
-  # Choose an origin node
-  start <- "24988"
-
-  hgdp.path <- dijkstraFrom(hgdp.sub, start)
-
-  expect_error(
-    gPath2dist(hgdp.path, res.type = "dist"),
-    "Length of x does not match a number of pairwise comparisons"
-  )
-})
-
-test_that("gPath2dist works correctly with dijkstraFrom output and res.type = 'vector'", {
-  hgdp.sub <- hgdp[c(1, 2, 3, 4), ]
-
-  # Choose an origin node
-  start <- "24988"
-
-  hgdp.path <- dijkstraFrom(hgdp.sub, start)
-
-  result <- gPath2dist(hgdp.path, res.type = "vector")
-
-  expect_true(is.numeric(result))
   expect_equal(length(result), 4L)
+  expect_false(is.null(names(result)))
 })
 
 test_that("gPath2dist builds a correctly sized dist when input locations share a node", {
@@ -76,7 +38,7 @@ test_that("gPath2dist builds a correctly sized dist when input locations share a
   hgdp.path <- dijkstraBetween(hgdp.sub)
   
   # check that gPath2dist still produces a dist object of the correct size
-  expect_no_warning(result <- gPath2dist(hgdp.path, res.type = "dist"))
+  expect_no_warning(result <- gPath2dist(hgdp.path))
   
   expect_s3_class(result, "dist")
   expect_equal(attr(result, "Size"), 4L)
@@ -87,8 +49,8 @@ test_that("gPath2dist places a zero distance for co-located nodes and stays cons
   hgdp.sub  <- hgdp[c(1, 1, 2, 3), ]
   hgdp.path <- dijkstraBetween(hgdp.sub)
   
-  result.dist <- gPath2dist(hgdp.path, res.type = "dist")
-  result.vec  <- gPath2dist(hgdp.path, res.type = "vector")
+  result.dist <- gPath2dist(hgdp.path)
+  result.vec  <- as.vector(result.dist)
   
   # the two co-located locations (1 and 2) have dist zero 
   expect_equal(as.matrix(result.dist)[1, 2], 0)
@@ -98,4 +60,30 @@ test_that("gPath2dist places a zero distance for co-located nodes and stays cons
   
   # dist and vector still describe the same distances
   expect_equal(as.vector(result.dist), as.vector(result.vec))
+})
+
+test_that("gPath2dist auto-detects dist for between and vector for from", {
+  coords <- data.frame(
+    lon = c(12.0, 12.0, -3.0, 24.0,  2.0, 19.0, -8.0, 28.0, 15.0,  5.0),
+    lat = c(50.0, 50.0, 40.0, 60.0, 48.0, 42.0, 53.0, 45.0, 55.0, 38.0)
+  )
+  rownames(coords) <- paste0("s", 1:10)
+  g <- new("gData", coords = coords, gGraph.name = "rawgraph.10k")
+  
+  mb <- dijkstraBetween(g[1:5])
+  mf <- dijkstraFrom(g, "7377")
+  
+  res_between <- gPath2dist(mb)
+  res_from    <- gPath2dist(mf)
+  
+  ## dijkstraBetween -> dist 
+  expect_s3_class(res_between, "dist")
+  expect_equal(attr(res_between, "Size"), 5L)
+  expect_equal(length(res_between), 10L)
+  
+  ## dijkstraFrom -> named numeric vector
+  expect_true(is.numeric(res_from))
+  expect_false(inherits(res_from, "dist"))
+  expect_equal(length(res_from), 10L)
+  expect_false(is.null(names(res_from)))
 })

--- a/tests/testthat/test_gPath2dist.R
+++ b/tests/testthat/test_gPath2dist.R
@@ -69,3 +69,33 @@ test_that("gPath2dist works correctly with dijkstraFrom output and res.type = 'v
   expect_true(is.numeric(result))
   expect_equal(length(result), 4L)
 })
+
+test_that("gPath2dist builds a correctly sized dist when input locations share a node", {
+  # rows 1 and 2 are the same location
+  hgdp.sub  <- hgdp[c(1, 1, 2, 3), ]
+  hgdp.path <- dijkstraBetween(hgdp.sub)
+  
+  # check that gPath2dist still produces a dist object of the correct size
+  expect_no_warning(result <- gPath2dist(hgdp.path, res.type = "dist"))
+  
+  expect_s3_class(result, "dist")
+  expect_equal(attr(result, "Size"), 4L)
+  expect_equal(length(result), 6L)
+})
+
+test_that("gPath2dist places a zero distance for co-located nodes and stays consistent", {
+  hgdp.sub  <- hgdp[c(1, 1, 2, 3), ]
+  hgdp.path <- dijkstraBetween(hgdp.sub)
+  
+  result.dist <- gPath2dist(hgdp.path, res.type = "dist")
+  result.vec  <- gPath2dist(hgdp.path, res.type = "vector")
+  
+  # the two co-located locations (1 and 2) have dist zero 
+  expect_equal(as.matrix(result.dist)[1, 2], 0)
+  # have identical distances to every other location
+  expect_equal(as.matrix(result.dist)[1, 3:4],
+               as.matrix(result.dist)[2, 3:4])
+  
+  # dist and vector still describe the same distances
+  expect_equal(as.vector(result.dist), as.vector(result.vec))
+})

--- a/tests/testthat/test_gPath2dist.R
+++ b/tests/testthat/test_gPath2dist.R
@@ -87,3 +87,29 @@ test_that("gPath2dist auto-detects dist for between and vector for from", {
   expect_equal(length(res_from), 10L)
   expect_false(is.null(names(res_from)))
 })
+
+
+test_that("gPath2dist errors on an broken gPath objects", {
+  # empty gPath
+  m <- structure(list(), class = "gPath")
+  expect_error(gPath2dist(m), "at least one element")
+  
+  # gPath with NULL names
+  m <- structure(list(list(length_detail = list(0))), class = "gPath")
+  expect_error(gPath2dist(m), "non-NULL names")
+  
+  # gPath with non-pairwise names
+  m <- structure(
+    list(list(length_detail = list(1)),
+         list(length_detail = list(2))),
+    class = "gPath"
+  )
+  names(m) <- c("a:x", "b:y")
+  expect_error(gPath2dist(m), "does not match a pairwise count")
+})
+
+test_that("gPath2dist emits a deprecation message when res.type is supplied", {
+  hgdp.sub  <- hgdp[c(1, 2, 3, 4), ]
+  hgdp.path <- dijkstraBetween(hgdp.sub)
+  expect_message(gPath2dist(hgdp.path, res.type = "dist"), "deprecated")
+})

--- a/tests/testthat/test_isInArea.R
+++ b/tests/testthat/test_isInArea.R
@@ -50,7 +50,7 @@ test_that("isInArea gives same nodes from zoom device and explicit bbox", {
   on.exit(dev.off(), add = TRUE)
 
   ## zoom into Europe on the device
-  plot(worldgraph.10k, reset = TRUE)
+  plot(worldgraph.10k, reset = TRUE, edges = TRUE, shape = NULL)
   geo.zoomin(list(x = c(-6, 38), y = c(35, 73)))
 
   ## get nodes from current plot and capture the reproducible call

--- a/tests/testthat/test_plot.gPath.R
+++ b/tests/testthat/test_plot.gPath.R
@@ -1,12 +1,15 @@
-test_that("plot.gPath works with custom color and lwd", {
-  hgdp.sub <- hgdp[getData(hgdp)$Population %in%
-    c("French", "Balochi", "BantuKenya", "Papuan", "Pima")]
+test_that("plot.gPath draws paths that connect the plotted points", {
+  hgdp.sub  <- hgdp[getData(hgdp)$Population %in%
+                      c("French", "Balochi", "BantuKenya", "Papuan", "Pima")]
   hgdp.path <- dijkstraBetween(hgdp.sub)
-
-  pdf(NULL)
-  on.exit(dev.off(), add = TRUE)
-  plot(worldgraph.40k)
-  expect_no_error(plot(hgdp.path, col = "blue", lwd = 1))
+  
+  pdf(NULL); on.exit(dev.off(), add = TRUE)
+  plot(worldgraph.40k, col = "NA")
+  points(hgdp.sub, col.nodes = "black", pch.nodes = 19)
+  expect_no_error((plot(hgdp.path, col = "blue", lwd = 1)))
+  
+  endpoints <- unique(unlist(strsplit(names(hgdp.path), ":", fixed = TRUE)))
+  expect_setequal(endpoints, unique(hgdp.sub@nodes.id))
 })
 
 test_that("print.gPath outputs correct number of paths", {

--- a/tests/testthat/test_polygonBetween.R
+++ b/tests/testthat/test_polygonBetween.R
@@ -76,9 +76,9 @@ test_that("polygonBetween outline = TRUE returns fewer or equal paths than outli
     from = "west", to = "east",
     outline = TRUE
   )
-  dist.all <- gPath2dist(result.all)
-  dist.outline <- gPath2dist(result.outline)
   if (!anyNA(result.outline)) {
+    dist.all <- gPath2dist(result.all)
+    dist.outline <- gPath2dist(result.outline)
     expect_lte(length(dist.outline), length(dist.all))
   }
 })

--- a/tests/testthat/test_polygonBetween.R
+++ b/tests/testthat/test_polygonBetween.R
@@ -76,8 +76,8 @@ test_that("polygonBetween outline = TRUE returns fewer or equal paths than outli
     from = "west", to = "east",
     outline = TRUE
   )
-  dist.all <- gPath2dist(result.all, res = "vec")
-  dist.outline <- gPath2dist(result.outline, res = "vec")
+  dist.all <- gPath2dist(result.all)
+  dist.outline <- gPath2dist(result.outline)
   if (!anyNA(result.outline)) {
     expect_lte(length(dist.outline), length(dist.all))
   }
@@ -125,8 +125,8 @@ test_that("polygonBetween distances are shorter for adjacent than distant polygo
   )
 
 
-  dist.adjacent <- gPath2dist(result.adjacent, res = "vec")
-  dist.distant <- gPath2dist(result.distant, res = "vec")
+  dist.adjacent <- gPath2dist(result.adjacent)
+  dist.distant <- gPath2dist(result.distant)
 
   expect_lt(
     min(dist.adjacent, na.rm = TRUE),

--- a/tests/testthat/test_setCosts.R
+++ b/tests/testthat/test_setCosts.R
@@ -178,5 +178,6 @@ test_that("setCosts errors when node.values is not numeric", {
 test_that("setCosts computes edge costs as the product of node costs", {
   g <- setCosts(worldgraph.10k, node.values = 2, method = "product")
   w <- vapply(g@graph@edgeData@data, function(e) e$weight, numeric(1))
+  expect_gt(length(w), 0)
   expect_true(all(w == 4))
 })

--- a/tests/testthat/test_setCosts.R
+++ b/tests/testthat/test_setCosts.R
@@ -53,7 +53,6 @@ test_that("setCosts with cost.rules updates meta and sets costs in one call", {
   expect_false(isTRUE(all.equal(result_w, baseline_w)))
 })
 
-
 test_that("setCosts with cost.rules must have exactly two columns", {
   cost.rules <- data.frame(
     habitat = c("sea", "land"),
@@ -122,4 +121,62 @@ test_that("setCosts accepts cost.rules with columns in any order", {
     getCosts(result.reversed, res.type = "vector"),
     getCosts(result.normal, res.type = "vector")
   )
+})
+
+
+test_that("setCosts errors when x is not a gGraph and when method = 'function' but FUN is NULL", {
+  expect_error(setCosts(list()), "x is not a valid gGraph object")
+  expect_error(setCosts("not_a_graph"), "x is not a valid gGraph object")
+  expect_error(
+    setCosts(worldgraph.10k, attr.name = "habitat", method = "function"),
+    "FUN needs to be defined"
+  )
+})
+
+
+test_that("setCosts errors when cost.rules is not a data.frame", {
+  expect_error(
+    setCosts(worldgraph.10k, attr.name = "habitat",
+             cost.rules = list(habitat = "sea", cost = 10)),
+    "cost.rules must be a data.frame"
+  )
+})
+
+test_that("setCosts errors when cost.rules lacks the attr.name column", {
+  cost.rules <- data.frame(foo = c("sea", "land"), cost = c(10, 1))
+  expect_error(
+    setCosts(worldgraph.10k, attr.name = "habitat", cost.rules = cost.rules),
+    "cost.rules must include the column named by attr.name"
+  )
+})
+
+test_that("setCosts errors when attr.name is absent from x@meta$costs", {
+  g <- worldgraph.10k
+  g@meta$costs <- data.frame(foo = c("sea", "land"), cost = c(10, 1))
+  expect_error(
+    setCosts(g, attr.name = "habitat"),
+    "attr.name is not documented"
+  )
+})
+
+test_that("setCosts errors when x has no costs component on the attribute path", {
+  g <- worldgraph.10k
+  g@meta$costs <- NULL
+  expect_error(
+    setCosts(g, attr.name = "habitat"),
+    "x@meta does not contain a 'costs' component"
+  )
+})
+
+test_that("setCosts errors when node.values is not numeric", {
+  expect_error(
+    setCosts(worldgraph.10k, node.values = c("a", "b", "c")),
+    "Provided 'node.values' not numeric"
+  )
+})
+
+test_that("setCosts computes edge costs as the product of node costs", {
+  g <- setCosts(worldgraph.10k, node.values = 2, method = "product")
+  w <- vapply(g@graph@edgeData@data, function(e) e$weight, numeric(1))
+  expect_true(all(w == 4))
 })

--- a/vignettes/geoGraph.Rmd
+++ b/vignettes/geoGraph.Rmd
@@ -363,7 +363,7 @@ We can extract the distances from the `origin` using `gPath2dist`, and then exam
 relationship between genetic diversity within populations (stored in `hgdp`) and the distance from the origin:
 ```{r fig=TRUE}
 div <- getData(hgdp)$"Genetic.Div"
-dgeo.unif <- gPath2dist(paths, res.type = "vector")
+dgeo.unif <- gPath2dist(paths)
 plot(div ~ dgeo.unif, xlab = "GeoGraphic distance (arbitrary units)", ylab = "Genetic diversity")
 lm.unif <- lm(div ~ dgeo.unif)
 abline(lm.unif, col = "red")
@@ -395,7 +395,7 @@ points(hgdp, col.nodes = "black")
 The new paths are slightly different from the previous ones.
 We can examine the new relationship with genetic distance:
 ```{r fig=TRUE}
-dgeo.hab <- gPath2dist(paths.2, res.type = "vector")
+dgeo.hab <- gPath2dist(paths.2)
 plot(div ~ dgeo.hab, xlab = "GeoGraphic distance (arbitrary units)", ylab = "Genetic diversity")
 lm.hab <- lm(div ~ dgeo.hab)
 abline(lm.hab, col = "red")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Behavior Changes**
  * `gPath2dist()` now automatically detects and returns the appropriate output format (distance matrix or vector) based on input type, eliminating manual selection.
  * The `res.type` parameter is now deprecated but remains functional for backward compatibility.

* **Documentation**
  * Updated function documentation and examples to reflect automatic output type detection.

* **Chores**
  * Version bumped to 1.1.1.9016.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->